### PR TITLE
Adding title to .show() to fix bug affecting some PIL versions

### DIFF
--- a/cv_imshow.py
+++ b/cv_imshow.py
@@ -236,7 +236,7 @@ class cv_imshow(gdb.Command):
         # Show image.
         img = Image.new(mode, (width, height))
         img.putdata(image_data)
-        img.show()
+        img.show("Image")
 
 
 cv_imshow()


### PR DESCRIPTION
In some versions of PIL the `.show()` method will fail if no title is provided. This was preventing the plugin from working for me.
![image](https://github.com/renatoGarcia/gdb-imshow/assets/21334530/8efc08f1-529d-45a3-b4ae-17a734077cca)
Adding a title (`.show("Image")`) fixes the issue.
